### PR TITLE
Correção de erros e failures ao rodar PHPUnit

### DIFF
--- a/src/Auxiliar/Identify.php
+++ b/src/Auxiliar/Identify.php
@@ -14,7 +14,7 @@ namespace NFePHP\MDFe\Auxiliar;
  */
 
 use \DOMDocument;
-use NFePHP\Common\Identify\Identify;
+use NFePHP\Common\Identify\Identify as CommonIdentify;
 
 class Identify
 {
@@ -37,8 +37,8 @@ class Identify
             'retEnviMDFe' => 'retEnviMDFe',
             'retEventoMDFe' => 'retEventoMDFe'
         );
-        Identify::setListSchemesId($aList);
-        $schem = Identify::identificacao($xml, $aResp);
+        CommonIdentify::setListSchemesId($aList);
+        $schem = CommonIdentify::identificacao($xml, $aResp);
         $dom = $aResp['dom'];
         $node = $dom->getElementsByTagName($aResp['tag'])->item(0);
         if ($schem == 'nfe') {

--- a/src/Make.php
+++ b/src/Make.php
@@ -45,7 +45,7 @@ class Make extends BaseMake
      * @var string
      */
     public $chMDFe = '';
-    
+
     //propriedades privadas utilizadas internamente pela classe
     private $MDFe = ''; //DOMNode
     private $infMDFe = ''; //DOMNode
@@ -60,7 +60,7 @@ class Make extends BaseMake
     private $aereo = ''; //DOMNode
     private $trem = ''; //DOMNode
     private $aqua = ''; //DOMNode
-    
+
     // Arrays
     private $aInfMunCarrega = array(); //array de DOMNode
     private $aInfPercurso = array(); //array de DOMNode
@@ -78,7 +78,7 @@ class Make extends BaseMake
     private $aInfTermDescarreg = array(); //array de DOMNode
     private $aInfEmbComb = array(); //array de DOMNode
     private $aCountDoc = array(); //contador de documentos fiscais
-    
+
     /**
      *
      * @return boolean
@@ -95,7 +95,7 @@ class Make extends BaseMake
         //tag ide [4]
         $this->dom->appChild($this->infMDFe, $this->ide, 'Falta tag "infMDFe"');
         //tag enderemit [30]
-        $this->appChild($this->emit, $this->enderEmit, 'Falta tag "emit"');
+        $this->dom->appChild($this->emit, $this->enderEmit, 'Falta tag "emit"');
         //tag emit [25]
         $this->dom->appChild($this->infMDFe, $this->emit, 'Falta tag "infMDFe"');
         //tag infModal [41]
@@ -112,13 +112,17 @@ class Make extends BaseMake
         $this->zTagLacres();
         //tag infAdic [78]
         $this->dom->appChild($this->infMDFe, $this->infAdic, 'Falta tag "infMDFe"');
+        // tag infMDFe
+        $this->dom->appChild($this->MDFe, $this->infMDFe, 'Falta tag "MDFe"');
+        // tag MDFe
+        $this->dom->appChild($this->dom, $this->MDFe, 'Falta DOMDocument');
         // testa da chave
         $this->zTestaChaveXML($this->dom);
         //convert DOMDocument para string
         $this->xml = $this->dom->saveXML();
         return true;
     }
-    
+
 
     /**
      * taginfMDFe
@@ -138,7 +142,7 @@ class Make extends BaseMake
         $this->chMDFe = $chave;
         return $this->infMDFe;
     }
-    
+
     /**
      * tgaide
      * Informações de identificação da MDFe 4 pai 1
@@ -293,7 +297,7 @@ class Make extends BaseMake
         $this->ide = $ide;
         return $ide;
     }
-    
+
     /**
      * tagInfMunCarrega
      *
@@ -325,7 +329,7 @@ class Make extends BaseMake
         $this->aInfMunCarrega[] = $infMunCarrega;
         return $infMunCarrega;
     }
-    
+
     /**
      * tagInfPercurso
      *
@@ -347,7 +351,7 @@ class Make extends BaseMake
         $this->aInfPercurso[] = $infPercurso;
         return $infPercurso;
     }
-    
+
     /**
      * tagemit
      * Identificação do emitente da MDFe [25] pai 1
@@ -378,7 +382,7 @@ class Make extends BaseMake
         $this->dom->addChild($this->emit, "xFant", $xFant, false, $identificador . "Nome fantasia do emitente");
         return $this->emit;
     }
-    
+
     /**
      * tagenderEmit
      * Endereço do emitente [30] pai [25]
@@ -515,7 +519,7 @@ class Make extends BaseMake
         $this->aInfMunDescarga[$nItem] = $infMunDescarga;
         return $infMunDescarga;
     }
-    
+
     /**
      * tagInfCTe
      * tag MDFe/infMDFe/infDoc/infMunDescarga/infCTe
@@ -548,7 +552,7 @@ class Make extends BaseMake
         $this->aInfCTe[$nItem][] = $infCTe;
         return $infCTe;
     }
-    
+
     /**
      * tagInfCT
      * tag MDFe/infMDFe/infDoc/infMunDescarga/infCT
@@ -608,7 +612,7 @@ class Make extends BaseMake
         $this->aInfCT[$nItem][] = $infCT;
         return $infCT;
     }
- 
+
     /**
      * tagInfNFe
      * tag MDFe/infMDFe/infDoc/infMunDescarga/infNFe
@@ -641,7 +645,7 @@ class Make extends BaseMake
         $this->aInfNFe[$nItem][] = $infNFe;
         return $infNFe;
     }
-    
+
     /**
      * tagInfNFe
      * tag MDFe/infMDFe/infDoc/infMunDescarga/infNF
@@ -719,7 +723,7 @@ class Make extends BaseMake
         $this->aInfNF[$nItem][] = $infNF;
         return $infNF;
     }
-    
+
     /**
      * tagTot
      * tag MDFe/infMDFe/tot
@@ -795,7 +799,7 @@ class Make extends BaseMake
         $this->tot = $tot;
         return $tot;
     }
-    
+
     /**
      * tagLacres
      * tag MDFe/infMDFe/lacres
@@ -817,7 +821,7 @@ class Make extends BaseMake
         $this->aLacres[] = $lacres;
         return $lacres;
     }
-    
+
     /**
      * taginfAdic
      * Grupo de Informações Adicionais Z01 pai A01
@@ -849,7 +853,7 @@ class Make extends BaseMake
         $this->infAdic = $infAdic;
         return $infAdic;
     }
-    
+
     /**
      * tagInfModal
      * tag MDFe/infMDFe/infModal
@@ -870,7 +874,7 @@ class Make extends BaseMake
         $this->infModal = $infModal;
         return $infModal;
     }
-    
+
     /**
      * tagAereo
      * tag MDFe/infMDFe/infModal/aereo
@@ -937,7 +941,7 @@ class Make extends BaseMake
         $this->aereo = $aereo;
         return $aereo;
     }
-    
+
     /**
      * tagTrem
      * tag MDFe/infMDFe/infModal/ferrov/trem
@@ -995,7 +999,7 @@ class Make extends BaseMake
         $this->trem = $trem;
         return $trem;
     }
-    
+
     /**
      * tagVag
      * tag MDFe/infMDFe/infModal/ferrov/trem/vag
@@ -1044,7 +1048,7 @@ class Make extends BaseMake
         $this->aVag[] = $vag;
         return $vag;
     }
-    
+
     /**
      * tagAqua
      * tag MDFe/infMDFe/infModal/Aqua
@@ -1111,7 +1115,7 @@ class Make extends BaseMake
         $this->aqua = $aqua;
         return $aqua;
     }
-    
+
     /**
      * tagInfTermCarreg
      * tag MDFe/infMDFe/infModal/Aqua/infTermCarreg
@@ -1177,7 +1181,7 @@ class Make extends BaseMake
         $this->aInfEmbComb[] = $infEmbComb;
         return $infEmbComb;
     }
-    
+
     /**
      * tagRodo
      * tag MDFe/infMDFe/infModal/rodo
@@ -1208,7 +1212,7 @@ class Make extends BaseMake
         $this->rodo = $rodo;
         return $rodo;
     }
-    
+
     /**
      * tagVeicPrincipal
      * tag MDFe/infMDFe/infModal/rodo/veicPrincipal
@@ -1233,7 +1237,7 @@ class Make extends BaseMake
         $this->veicPrincipal = $veicPrincipal;
         return $veicPrincipal;
     }
-    
+
     /**
      * tagCondutor
      * tag MDFe/infMDFe/infModal/rodo/veicPrincipal/condutor
@@ -1264,7 +1268,7 @@ class Make extends BaseMake
         $this->aCondutor[] = $condutor;
         return $condutor;
     }
-    
+
     /**
      * tagVeicReboque
      * tag MDFe/infMDFe/infModal/rodo/reboque
@@ -1329,7 +1333,7 @@ class Make extends BaseMake
         $this->aDisp[] = $disp;
         return $disp;
     }
-    
+
     /**
      * zTagVeiculo
      *
@@ -1399,7 +1403,7 @@ class Make extends BaseMake
         }
         return $node;
     }
-    
+
     /**
      * zTagMDFe
      * Tag raiz da MDFe
@@ -1416,7 +1420,7 @@ class Make extends BaseMake
         }
         return $this->MDFe;
     }
-    
+
     /**
      * Adiciona as tags
      * infMunCarrega e infPercurso
@@ -1427,7 +1431,7 @@ class Make extends BaseMake
         $this->dom->addArrayChild($this->ide, $this->aInfMunCarrega);
         $this->dom->addArrayChild($this->ide, $this->aInfPercurso);
     }
-    
+
     /**
      * Processa lacres
      */
@@ -1492,7 +1496,7 @@ class Make extends BaseMake
             $this->dom->appChild($this->infModal, $ferrov, 'Falta tag "infModal"');
         }
     }
-    
+
     /**
      * Processa modal aereo
      */
@@ -1502,7 +1506,7 @@ class Make extends BaseMake
             $this->dom->appChild($this->infModal, $this->aereo, 'Falta tag "infModal"');
         }
     }
-    
+
     /**
      * Processa modal aquaviário
      */
@@ -1515,7 +1519,7 @@ class Make extends BaseMake
             $this->dom->appChild($this->infModal, $this->aqua, 'Falta tag "infModal"');
         }
     }
-    
+
     /**
      * zTestaChaveXML
      * Remonta a chave da NFe de 44 digitos com base em seus dados

--- a/tests/Auxiliar/IdentifyTest.php
+++ b/tests/Auxiliar/IdentifyTest.php
@@ -11,7 +11,7 @@ class IdentifyTest extends PHPUnit_Framework_TestCase
     public function testeIdentificaMDFe()
     {
         $aResp = array();
-        $filePath = dirname(dirname(__FILE__)) . '/fixtures/xml/MDFe/MDFe41140581452880000139580010000000281611743166.xml';
+        $filePath = dirname(dirname(__FILE__)) . '/fixtures/xml/MDFe41140581452880000139580010000000281611743166.xml';
         $schem = Identify::identificar($filePath, $aResp);
         $this->assertEquals($schem, 'mdfe');
     }

--- a/tests/Auxiliar/ResponseTest.php
+++ b/tests/Auxiliar/ResponseTest.php
@@ -9,7 +9,7 @@ use NFePHP\MDFe\Response;
 class ResponseTest extends PHPUnit_Framework_TestCase
 {
     public $mdfe;
-    
+
     public function testeInstanciar()
     {
         $this->mdfe = new Response();

--- a/tests/ConvertTest.php
+++ b/tests/ConvertTest.php
@@ -9,7 +9,7 @@ use NFePHP\MDFe\Convert;
 class ConvertTest extends PHPUnit_Framework_TestCase
 {
     public $mdfe;
-    
+
     public function testeInstanciar()
     {
         $this->mdfe = new Convert();

--- a/tests/MailTest.php
+++ b/tests/MailTest.php
@@ -9,10 +9,10 @@ use NFePHP\MDFe\Mail;
 class MailTest extends PHPUnit_Framework_TestCase
 {
     public $mail;
-    
+
     public function testeInstanciar()
     {
-        $configJson = file_get_contents(dirname(dirname(__FILE__)) . '/fixtures/config/fakeconfig.json');
+        $configJson = file_get_contents(dirname(dirname(__FILE__)) . '/tests/fixtures/config/fakeconfig.json');
         $json = json_decode($configJson);
         $aMail = (array) $json->aMailConf;
         $this->mail = new Mail($aMail);

--- a/tests/ToolsTest.php
+++ b/tests/ToolsTest.php
@@ -4,18 +4,18 @@
  * Class ToolsMDFeTest
  * @author Roberto L. Machado <linux.rlm at gmail dot com>
  */
-use NFePHP\MDFe\ToolsMDFe;
+use NFePHP\MDFe\Tools;
 
 class ToolsMDFeTest extends PHPUnit_Framework_TestCase
 {
     public $mdfe;
-    
+
     /**
      * @expectedException NFePHP\Common\Exception\InvalidArgumentException
      */
     public function testeInstanciar()
     {
-        $configJson = dirname(dirname(__FILE__)) . '/fixtures/config/fakeconfig.json';
-        $this->mdfe = new ToolsMDFe($configJson);
+        $configJson = dirname(dirname(__FILE__)) . '/tests/fixtures/config/fakeconfig.json';
+        $this->mdfe = new Tools($configJson);
     }
 }


### PR DESCRIPTION
O teste **ConvertTest** não passou no build por que não existe a classe **Convert** no projeto como existe no **sped-nfe** e **sped-cte**, então preferi não mexer.