### PR TITLE
Typo no body do xml em sefazConsultaNaoEncerrados

### DIFF
--- a/src/Tools.php
+++ b/src/Tools.php
@@ -771,7 +771,7 @@ class Tools extends BaseTools
         //    throw new Exception\RuntimeException($msg);
         //}
         //montagem dos dados da mensagem SOAP
-        $body = "<mdefDadosMsg xmlns=\"$this->urlNamespace\">$cons</mdfeDadosMsg>";
+        $body = "<mdfeDadosMsg xmlns=\"$this->urlNamespace\">$cons</mdfeDadosMsg>";
         //consome o webservice e verifica o retorno do SOAP
         $retorno = $this->oSoap->send(
             $this->urlService,


### PR DESCRIPTION
`mdfeDadosMsg` estava como `mdefDadosMsg` e obviamente a chamada falhava. 
 
Versao da config tbm estava 1.0 ao inves de 1.00 e tbm falhava (não acho que esteja errado no modelo, mas vou checar). 
 
O nome dos arquivos gerados pelo método `sefazConsultaNaoEncerrados` são impossiveis de prever (data_hora) e nao sao retornados na função (fica difícil pegar eles). Infelizmente vou ter que modificar isso aqui pra poder pegar os nomes dos arquivos (ou mudar os nomes para algo mais estatico).