### PR TITLE
zReadConsNaoEnc($dom) lendo protocolo como chave

### DIFF
--- a/src/Auxiliar/Response.php
+++ b/src/Auxiliar/Response.php
@@ -285,7 +285,7 @@ class Response
             foreach ($lista as $infMDFe) {
                 $aMDFe[] = array(
                     'chMDFe' => $dom->getValue($infMDFe, 'chMDFe'),
-                    'nProt' => $dom->getValue($infMDFe, 'chMDFe')
+                    'nProt' => $dom->getValue($infMDFe, 'nProt')
                 );
             }
         }


### PR DESCRIPTION
Provavelmente esqueceram de modificar depois de copiar e colar a linha anterior. Notei que o XML estava correto e achei o erro aqui. Desculpa postar direto no github, mas eu ia esquecer se já não fizesse, além de ser uma mudança besta.