### PR TITLE
Ajuste emitente CPF

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -158,6 +158,7 @@ class Make
 
     /**
      * Retorns the xml
+     *
      * @return xml
      */
     public function getXML()
@@ -170,6 +171,7 @@ class Make
 
     /**
      * Retorns the key number of NFe (44 digits)
+     *
      * @return string
      */
     public function getChave()
@@ -179,6 +181,7 @@ class Make
 
     /**
      * Returns the model of MDFe
+     *
      * @return int
      */
     public function getModelo()
@@ -188,6 +191,7 @@ class Make
 
     /**
      * Call method of xml assembly. For compatibility only.
+     *
      * @return boolean
      */
     public function montaMDFe()
@@ -200,6 +204,7 @@ class Make
      * this function returns TRUE on success or FALSE on error
      * The xml of the MDFe must be retrieved by the getXML() function or
      * directly by the public property $xml
+     *
      * @return boolean
      */
     public function monta()
@@ -248,6 +253,7 @@ class Make
     /**
      * Informações de identificação da MDFe
      * tag MDFe/infMDFe/ide
+     *
      * @param  stdClass $std
      * @return DOMElement
      */
@@ -473,6 +479,7 @@ class Make
     {
         $possible = [
             'CNPJ',
+            'CPF',
             'IE',
             'xNome',
             'xFant'
@@ -485,8 +492,15 @@ class Make
             $this->emit,
             "CNPJ",
             $std->CNPJ,
-            true,
+            false,
             $identificador . "CNPJ do emitente"
+        );
+        $this->dom->addChild(
+            $this->emit,
+            "CPF",
+            $std->CPF,
+            false,
+            $identificador . "CPF do emitente"
         );
         $this->dom->addChild(
             $this->emit,
@@ -1315,17 +1329,17 @@ class Make
             'nLacre'
         ];
         $std = $this->equilizeParameters($std, $possible);
-		foreach ($std->nLacre as $nLacre) {
-			$lacres = $this->dom->createElement("lacres");
-			$this->dom->addChild(
-				$lacres,
-				"nLacre",
-				$nLacre,
-				false,
-				"Número do lacre"
-			);
-			$this->aLacres[] = $lacres; //array de DOMNode
-		}
+        foreach ($std->nLacre as $nLacre) {
+            $lacres = $this->dom->createElement("lacres");
+            $this->dom->addChild(
+                $lacres,
+                "nLacre",
+                $nLacre,
+                false,
+                "Número do lacre"
+            );
+            $this->aLacres[] = $lacres; //array de DOMNode
+        }
         return $this->aLacres;
     }
 
@@ -1416,12 +1430,12 @@ class Make
      * tagAereo
      * tag MDFe/infMDFe/infModal/aereo
      *
-     * @param  string $nac
-     * @param  string $matr
-     * @param  string $nVoo
-     * @param  string $cAerEmb
-     * @param  string $cAerDes
-     * @param  string $dVoo
+     * @param string $nac
+     * @param string $matr
+     * @param string $nVoo
+     * @param string $cAerEmb
+     * @param string $cAerDes
+     * @param string $dVoo
      *
      * @return DOMElement
      */
@@ -1485,11 +1499,11 @@ class Make
      * tagTrem
      * tag MDFe/infMDFe/infModal/ferrov/trem
      *
-     * @param  string $xPref
-     * @param  string $dhTrem
-     * @param  string $xOri
-     * @param  string $xDest
-     * @param  string $qVag
+     * @param string $xPref
+     * @param string $dhTrem
+     * @param string $xOri
+     * @param string $xDest
+     * @param string $qVag
      *
      * @return DOMElement
      */
@@ -1545,10 +1559,10 @@ class Make
      * tagVag
      * tag MDFe/infMDFe/infModal/ferrov/trem/vag
      *
-     * @param  string $serie
-     * @param  string $nVag
-     * @param  string $nSeq
-     * @param  string $tonUtil
+     * @param string $serie
+     * @param string $nVag
+     * @param string $nSeq
+     * @param string $tonUtil
      *
      * @return DOMElement
      */
@@ -1596,12 +1610,12 @@ class Make
      * tagAqua
      * tag MDFe/infMDFe/infModal/Aqua
      *
-     * @param  string $cnpjAgeNav
-     * @param  string $tpEmb
-     * @param  string $cEmbar
-     * @param  string $nViagem
-     * @param  string $cPrtEmb
-     * @param  string $cPrtDest
+     * @param string $cnpjAgeNav
+     * @param string $tpEmb
+     * @param string $cEmbar
+     * @param string $nViagem
+     * @param string $cPrtEmb
+     * @param string $cPrtDest
      *
      * @return DOMElement
      */
@@ -1665,7 +1679,7 @@ class Make
      * tagInfTermCarreg
      * tag MDFe/infMDFe/infModal/Aqua/infTermCarreg
      *
-     * @param  string $cTermCarreg
+     * @param string $cTermCarreg
      *
      * @return DOMElement
      */
@@ -1687,7 +1701,7 @@ class Make
      * tagInfTermDescarreg
      * tag MDFe/infMDFe/infModal/Aqua/infTermDescarreg
      *
-     * @param  string cTermDescarreg
+     * @param string cTermDescarreg
      *
      * @return DOMElement
      */
@@ -1709,7 +1723,7 @@ class Make
      * tagInfEmbComb
      * tag MDFe/infMDFe/infModal/Aqua/infEmbComb
      *
-     * @param  string cEmbComb
+     * @param string cEmbComb
      *
      * @return DOMElement
      */
@@ -1865,24 +1879,24 @@ class Make
                 'CPF'
             ];
             foreach ($std->condutor as $condutor) {
-				$stdcondutor = $this->equilizeParameters($condutor, $possible);
-				$tagcondutor = $this->dom->createElement("condutor");
-				$this->dom->addChild(
-					$tagcondutor,
-					"xNome",
-					$stdcondutor->xNome,
-					true,
-					"Nome do Condutor "
-				);
-				$this->dom->addChild(
-					$tagcondutor,
-					"CPF",
-					$stdcondutor->CPF,
-					true,
-					"CPF do Condutor "
-				);
-				$this->dom->appChild($veicTracao, $tagcondutor, 'Falta tag "veicTracao"');
-			}
+                $stdcondutor = $this->equilizeParameters($condutor, $possible);
+                $tagcondutor = $this->dom->createElement("condutor");
+                $this->dom->addChild(
+                    $tagcondutor,
+                    "xNome",
+                    $stdcondutor->xNome,
+                    true,
+                    "Nome do Condutor "
+                );
+                $this->dom->addChild(
+                    $tagcondutor,
+                    "CPF",
+                    $stdcondutor->CPF,
+                    true,
+                    "CPF do Condutor "
+                );
+                $this->dom->appChild($veicTracao, $tagcondutor, 'Falta tag "veicTracao"');
+            }
         }
         $this->dom->addChild(
             $veicTracao,
@@ -2153,7 +2167,11 @@ class Make
         $emit = $dom->getElementsByTagName("emit")->item(0);
         $cUF = $ide->getElementsByTagName('cUF')->item(0)->nodeValue;
         $dhEmi = $ide->getElementsByTagName('dhEmi')->item(0)->nodeValue;
-        $cnpj = $emit->getElementsByTagName('CNPJ')->item(0)->nodeValue;
+        if (!empty($emit->getElementsByTagName('CNPJ')->item(0)->nodeValue)) {
+            $doc = $emit->getElementsByTagName('CNPJ')->item(0)->nodeValue;
+        } else {
+            $doc = $emit->getElementsByTagName('CPF')->item(0)->nodeValue;
+        }
         $mod = $ide->getElementsByTagName('mod')->item(0)->nodeValue;
         $serie = $ide->getElementsByTagName('serie')->item(0)->nodeValue;
         $nMDF = $ide->getElementsByTagName('nMDF')->item(0)->nodeValue;
@@ -2165,7 +2183,7 @@ class Make
             $cUF,
             $dt->format('y'),
             $dt->format('m'),
-            $cnpj,
+            $doc,
             $mod,
             $serie,
             $nMDF,
@@ -2186,8 +2204,9 @@ class Make
     /**
      * Includes missing or unsupported properties in stdClass
      * Replace all unsuported chars
-     * @param stdClass $std
-     * @param array $possible
+     *
+     * @param  stdClass $std
+     * @param  array    $possible
      * @return stdClass
      */
     protected function equilizeParameters(stdClass $std, $possible)


### PR DESCRIPTION
Ajustes necessários para criar as tags do emissor com CPF. Emitente pode ser CNPJ ou CPF. Quando emissor com CPF, chave de acesso completa o CPF com 0 a esquerda.