### PR TITLE
Correção de campos obrigatórios e tag TpProp para tpProp

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1817,7 +1817,7 @@ class Make
                 'xNome',
                 'IE',
                 'UF',
-                'TpProp'
+                'tpProp'
             ];
             $stdprop = $this->equilizeParameters($std->prop, $possible);
             $prop = $this->dom->createElement("prop");
@@ -1825,14 +1825,14 @@ class Make
                 $prop,
                 "CPF",
                 $stdprop->CPF,
-                true,
+                false,
                 "Número do CPF"
             );
             $this->dom->addChild(
                 $prop,
                 "CNPJ",
                 $stdprop->CNPJ,
-                true,
+                false,
                 "Número do CNPJ"
             );
             $this->dom->addChild(
@@ -1865,8 +1865,8 @@ class Make
             );
             $this->dom->addChild(
                 $prop,
-                "TpProp",
-                $stdprop->TpProp,
+                "tpProp",
+                $stdprop->tpProp,
                 true,
                 "Tipo Proprietário"
             );
@@ -1996,7 +1996,7 @@ class Make
                 'xNome',
                 'IE',
                 'UF',
-                'TpProp'
+                'tpProp'
             ];
             $stdprop = $this->equilizeParameters($std->prop, $possible);
             $prop = $this->dom->createElement("prop");
@@ -2004,14 +2004,14 @@ class Make
                 $prop,
                 "CPF",
                 $stdprop->CPF,
-                true,
+                false,
                 "Número do CPF"
             );
             $this->dom->addChild(
                 $prop,
                 "CNPJ",
                 $stdprop->CNPJ,
-                true,
+                false,
                 "Número do CNPJ"
             );
             $this->dom->addChild(
@@ -2044,8 +2044,8 @@ class Make
             );
             $this->dom->addChild(
                 $prop,
-                "TpProp",
-                $stdprop->TpProp,
+                "tpProp",
+                $stdprop->tpProp,
                 true,
                 "Tipo Proprietário"
             );


### PR DESCRIPTION
Campos CPF/CNPJ conflitando informações. Caso insira CPF ele solicita CNPJ e mesma coisa do contrario na geração do XML.


Campo tpProp não tem o **T** em maiúsculo segundo a documentação do MDFe 3.00a, segue a imagem abaixo do campo. Caso mantendo com maiúsculo ocasiona um erro genérico de XML inválido no retorno.

![Captura de tela de 2019-10-03 14-50-45](https://user-images.githubusercontent.com/35309750/66155320-5bb35500-e5ed-11e9-95c7-35ecbf7c3a6d.png)

