### PR TITLE
Ajusta tipo de string genérico no schema

### DIFF
--- a/schemes/PL_MDFe_300a/tiposGeralMDFe_v3.00.xsd
+++ b/schemes/PL_MDFe_300a/tiposGeralMDFe_v3.00.xsd
@@ -562,7 +562,7 @@
 		</xs:annotation>
 		<xs:restriction base="xs:string">
 			<xs:whiteSpace value="preserve"/>
-			<xs:pattern value="[!-ÿ]{1}[ -ÿ]{0,}[!-ÿ]{1}|[!-ÿ]{1}"/>
+			<xs:pattern value="[!-ÿ]{1}[ -ÿ]*[!-ÿ]{1}|[!-ÿ]{1}"/>
 		</xs:restriction>
 	</xs:simpleType>
 	<xs:simpleType name="TData">


### PR DESCRIPTION
Vocês tem problema com esse campo também?
Com a atual expressão regular da erro de validação no grEmb por exemplo, tentando enviar o valor "II", que bate com a expressão regular mas no PHP não funciona.