### PR TITLE
refatorado o metodo tagtot para aceitar passar os campos qCTe, qNFe, …

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1502,22 +1502,40 @@ class Make
     public function tagtot(stdClass $std)
     {
         $possible = [
+            'qCTe',
+            'qNFe',
+            'qMDFe',
             'vCarga',
             'cUnid',
             'qCarga'
         ];
         $std = $this->equilizeParameters($std, $possible);
-        $std->qCTe = count($this->infCTe);
-        if ($std->qCTe == 0) {
-            $std->qCTe = '';
+        if (!isset($std->qCTe)) {
+            $std->qCTe = 0;
+            foreach ($this->infCTe as $infCTe) {
+                $std->qCTe += count($infCTe);
+            }
+            if ($std->qCTe == 0) {
+                $std->qCTe = '';
+            }
         }
-        $std->qNFe = count($this->infNFe);
-        if ($std->qNFe == 0) {
-            $std->qNFe = '';
+        if (!isset($std->qNFe)) {
+            $std->qNFe = 0;
+            foreach ($this->infNFe as $infNFe) {
+                $std->qNFe += count($infNFe);
+            }
+            if ($std->qNFe == 0) {
+                $std->qNFe = '';
+            }
         }
-        $std->qMDFe = count($this->infMDFeTransp);
-        if ($std->qMDFe == 0) {
-            $std->qMDFe = '';
+        if (!isset($std->qMDFe)) {
+            $std->qMDFe = 0;
+            foreach ($this->infMDFeTransp as $infMDFeTransp) {
+                $std->qMDFe += count($infMDFeTransp);
+            }
+            if ($std->qMDFe == 0) {
+                $std->qMDFe = '';
+            }
         }
         $tot = $this->dom->createElement("tot");
         $this->dom->addChild(


### PR DESCRIPTION
Eu tive problemas com o campo qNFe(da quantidade de notas fiscais) na tag dos totais quando existem mais de uma cidade para o mesmo estado.

Exemplo: Vou descarregar em 3 cidades diferentes para o mesmo estado. 10 notas para a cidade 1; 8 notas para a cidade 2 e 2 notas para a cidade 3. Ao invés do campo qNFe receber 20 notas ela estava recebendo 3 que é numero de cidades.

Então fiz ajustes para permitir que o campo qNFe pudesse ser informado manualmente e ajustei para fazer os calculos correto (no caso colocar 20 no campo qNFe).