### PR TITLE
Permitindo informar tag IE vazia

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -2354,7 +2354,8 @@ class Make
                 "IE",
                 $stdprop->IE,
                 true,
-                $identificadorProp . "Inscrição Estadual"
+                $identificadorProp . "Inscrição Estadual",
+                true
             );
             $this->dom->addChild(
                 $prop,


### PR DESCRIPTION
A expressão regular que valida a IE do proprietário do veículo é: ``[0-9]{0,14}|ISENTO|PR[0-9]{4,8}``
Tenho casos de proprietários que tem CNPJ, não tem IE e não são ISENTOS. Na API antiga da MDF-e já estava sendo tratado isso.
Poderia lançar um novo release com essa correção?