### PR TITLE
Grupo produto predominante deve ser informado para modal rodoviário

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -314,7 +314,8 @@ class Make
         $this->dom->appChild($this->emit, $this->enderEmit, 'Falta tag "enderEmit"');
         $this->dom->appChild($this->infMDFe, $this->emit, 'Falta tag "emit"');
         if ($this->rodo) {
-            if (empty($this->prodPred)) {
+            $tpEmit = $this->ide->getElementsByTagName('tpEmit')->item(0)->nodeValue;
+            if (($tpEmit == 1 || $tpEmit == 3) && empty($this->prodPred)) {
                 $this->errors[] = "Tag prodPred é obrigatória para modal rodoviário!";
             }
             if (empty($this->infLotacao) and ($this->contaDoc($this->infCTe) + $this->contaDoc($this->infNFe) + $this->contaDoc($this->infMDFeTransp)) == 1) {


### PR DESCRIPTION
Bom dia

Acredito ter encontrado um bug na lib. Ao tentar enviar um manifesto rodoviario que o campo tpEmit está com valor 2 está dando o erro “Grupo produto predominante deve ser informado para modal rodoviário”

Seguindo esse link

https://www.oobj.com.br/bc/article/rejei%C3%A7%C3%A3o-725-grupo-produto-predominante-deve-ser-informado-para-modal-rodovi%C3%A1rio-como-resolver-982.html

Percebi que esse erro só poderia aparecer se o tpEmit fosse 1 ou 3, por isso estou enviando uma Pull Request com uma sugestão para a correção desse problema.