### PR TITLE
bugfix: regra para apenas um DFe informado

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -318,7 +318,7 @@ class Make
             if (($tpEmit == 1 || $tpEmit == 3) && empty($this->prodPred)) {
                 $this->errors[] = "Tag prodPred é obrigatória para modal rodoviário!";
             }
-            if (empty($this->infLotacao) and ($this->contaDoc($this->infCTe) + $this->contaDoc($this->infNFe) + $this->contaDoc($this->infMDFeTransp)) == 1) {
+            if (($tpEmit == 1 || $tpEmit == 3) && empty($this->infLotacao) && ($this->contaDoc($this->infCTe) + $this->contaDoc($this->infNFe) + $this->contaDoc($this->infMDFeTransp)) == 1) {
                 $this->errors[] = "Tag infLotacao é obrigatória quando só existir um Documento informado!";
             }
             if ($this->infANTT) {


### PR DESCRIPTION
A regra para informar a tag infLotacao caso apenas um DF seja informado no grupo infDoc (NT 2020.001) é valida apenas para tipos de emitente 1 e 3, conforme:

`
Se modal rodoviário e Tipo Emitente for igual a Prestador de Serviço de Transporte Facult. 726 Rej. (tpEmit=1) ou transportador que emitirá CT-e globalizado (tpEmit=3) e MDF-e possuir
apenas um DF-e transportado no grupo infDoc:
O grupo de informações da carga lotação (infLotacao) deve estar informado
`

Portanto, adicionei a condição que valida os tipos 1 ou 3.