### PR TITLE
Correção UF de licenciamento de veículos e CNPJ taginfContratante

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1009,7 +1009,7 @@ class Make
         $possible = [
             'xNome',
             'CPF',
-            'CPF',
+            'CNPJ',
             'idEstrangeiro'
         ];
         $std = $this->equilizeParameters($std, $possible);

--- a/src/Make.php
+++ b/src/Make.php
@@ -2724,7 +2724,7 @@ class Make
             $veicTracao,
             "UF",
             $std->UF,
-            true,
+            false,
             $identificador . "UF de licenciamento do veículo"
         );
         $this->veicTracao = $veicTracao;
@@ -2874,7 +2874,7 @@ class Make
             $veicReboque,
             "UF",
             $std->UF,
-            true,
+            false,
             $identificador . "UF de licenciamento do veículo"
         );
         $this->veicReboque[] = $veicReboque;


### PR DESCRIPTION
**NT 2021.001** - Tornar a UF da placa opcional em virtude da nova placa padrão Mercosul.

**Correção** - taginfContratante - a chave 'CPF' está repetida dentro do array $possible. Corrigido para 'CNPJ'.