### PR TITLE
Adiciona tag do responsável técnico ao XML do MDF-e

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -161,6 +161,10 @@ class Make
     /**
      * @type string|\DOMNode
      */
+    private $infRespTec = '';
+    /**
+     * @type string|\DOMNode
+     */
     private $rodo = '';
     /**
      * @type string|\DOMNode
@@ -447,6 +451,9 @@ class Make
         }
         if (!empty($this->infAdic)) {
             $this->dom->appChild($this->infMDFe, $this->infAdic, 'Falta tag "infAdic"');
+        }
+        if (!empty($this->infRespTec)) {
+            $this->dom->appChild($this->infMDFe, $this->infRespTec, 'Falta tag "infRespTec"');
         }
         $this->dom->appChild($this->MDFe, $this->infMDFe, 'Falta tag "infMDFe"');
         $this->dom->appendChild($this->MDFe);


### PR DESCRIPTION
Adiciona a tag infRespTec no xml do MDF-e, antes mesmo informando os dados, na função monta(), não estava sendo gerada a tag. Alguns estados estão solicitando este registro no XML.