### PR TITLE
correções IE e UF no veiculo tração e reboque

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -2721,14 +2721,15 @@ class Make
                 $prop,
                 "IE",
                 $stdprop->IE,
-                false,
-                $identificadorProp . "Inscrição Estadual"
+                true,
+                $identificadorProp . "Inscrição Estadual",
+                true
             );
             $this->dom->addChild(
                 $prop,
                 "UF",
                 $stdprop->UF,
-                false,
+                true,
                 $identificadorProp . "Unidade da Federação"
             );
             $this->dom->addChild(
@@ -2887,14 +2888,15 @@ class Make
                 $prop,
                 "IE",
                 $stdprop->IE,
-                false,
-                $identificadorprop . "Inscrição Estadual"
+                true,
+                $identificadorprop . "Inscrição Estadual",
+                true
             );
             $this->dom->addChild(
                 $prop,
                 "UF",
                 $stdprop->UF,
-                false,
+                true,
                 $identificadorprop . "Unidade da Federação"
             );
             $this->dom->addChild(


### PR DESCRIPTION
Ola, identificamos uma inconsistência durante a emissão quando o proprietário do veículo (seja de tração ou de reboque)  não tem um IE e nem é ISENTO, isso está impedindo de emitir, a validação está bloqueando.

Olhando o histórico do código, isto já havia sido feito mas por algum motivo foi desfeito, só que o formato antigo era o correto, seguindo a documentação do MDF-e

![image](https://user-images.githubusercontent.com/8661764/231271129-e6eac565-e8e6-4f90-aad0-4c4adad1926b.png)

O campo IE precisa sempre existir, mesmo que vazio. Já o UF precisa existir e sempre preenchido, então basicamente desfiz as alterações do commit `a55ca70c5dcb06d7a4b79f76c96ce687bbfa376e`

Qualquer dúvida ou inconsistência, da um alô.

Valeu!