### PR TITLE
Declarar propriedades que eram dinâmicas

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -230,6 +230,26 @@ class Make
      * @var null
      */
     private $categCombVeic = null;
+    /**
+     * @type \DOMImproved
+     */
+    protected $dom;
+    /**
+     * @type false|string
+     */
+    protected $xml;
+    /**
+     * @type array
+     */
+    protected $lacres;
+    /**
+     * @type string
+     */
+    protected $tpAmb;    
+    /**
+    * @type string
+    */
+    protected $csrt;
 
     /**
      * Função construtora cria um objeto DOMDocument


### PR DESCRIPTION
Essa PR visa corrigir o seguinte erro nas versões mais recentes do PHP (>=8.2):

> `Deprecated: Creation of dynamic property $dom is deprecated`

Esse erro acontece ao atribuir uma variável da classe sem tê-la declarado