### PR TITLE
feat: Corrige tag de protocolação dos eventos

### DIFF
--- a/src/Complements.php
+++ b/src/Complements.php
@@ -111,22 +111,10 @@ class Complements
             throw DocumentsException::wrongDocument(4, "[$cStat] $xMotivo");
         }
 
-        $tpEvento = $retEv->getElementsByTagName('tpEvento')->item(0)->nodeValue;
-        if ($tpEvento == '110111') {
-            $node = 'procCancMDFe';
-        } elseif ($tpEvento == '110112') {
-            $node = 'procEncMDFe';
-        } elseif ($tpEvento == '110114') {
-            $node = 'procIncCondutor';
-        } elseif ($tpEvento == '110115') {
-            $node = 'procIncDFe';
-        } else {
-            throw DocumentsException::wrongDocument(4, "Evento não disponivel.");
-        }
         return self::join(
             $ev->saveXML($event),
             $ret->saveXML($retEv),
-            $node,
+            'procEventoMDFe',
             $versao
         );
     }


### PR DESCRIPTION
As tags que estavam sendo passadas ao protocolar os eventos do MDFe são inválidas.
A tag correta sempre é `procEventoMDFe`.

@icompsoftcleiton @cleitonperin 