### PR TITLE
fix: Adiciona os parâmetros de verificação no 'infUnidTransp' e 'peri' na classe Make

### DIFF
--- a/src/Make.php
+++ b/src/Make.php
@@ -1446,6 +1446,8 @@ class Make
         $possible = [
             'chMDFe',
             'indReentrega',
+            'infUnidTransp',
+            'peri',
             'nItem'
         ];
         $std = $this->equilizeParameters($std, $possible);


### PR DESCRIPTION
Adiciona os parâmetros infUnidTransp e peri à validação da classe Make, garantindo que sejam corretamente reconhecidos e processados.